### PR TITLE
Style homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,8 @@
 ---
 layout: home
+title: Humboldt Extension for Ecological Inventories
+description: The Humboldt Extension for Ecological Inventories is a vocabulary for transmitting information about biological inventories with hierarchical event data. It is used along with Darwin Core terms to extend descriptions of Events.
 ---
-
-# Humboldt Extension for Ecological Inventories
-
-Abstract : The Humboldt Extension for Ecological Inventories is a vocabulary for transmitting information about biological inventories with hierarchical event data. It is used along with Darwin Core terms to extend descriptions of Events. 
 
 NOTE: This document forms part of a proposal by the [Humboldt Core Task Group](https://www.tdwg.org/community/osr/humboldt-core/) to extend Darwin Core with vocabulary for ecological inventories. It is not yet ratified and may change as a result of recommendations received during the course of open public commentary. To help reviewers understand how the extension was tested and what was learned from that testing, an [Implementation Experience Report](https://docs.google.com/document/d/1RFdSHoyzWCQk9qO6uup4xQjWOMzPyBb-A0mcjj98hbk/edit?usp=sharing) is available.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ title: Humboldt Extension for Ecological Inventories
 description: The Humboldt Extension for Ecological Inventories is a vocabulary for transmitting information about biological inventories with hierarchical event data. It is used along with Darwin Core terms to extend descriptions of Events.
 ---
 
+{:.alert .alert-warning}
 NOTE: This document forms part of a proposal by the [Humboldt Core Task Group](https://www.tdwg.org/community/osr/humboldt-core/) to extend Darwin Core with vocabulary for ecological inventories. It is not yet ratified and may change as a result of recommendations received during the course of open public commentary. To help reviewers understand how the extension was tested and what was learned from that testing, an [Implementation Experience Report](https://docs.google.com/document/d/1RFdSHoyzWCQk9qO6uup4xQjWOMzPyBb-A0mcjj98hbk/edit?usp=sharing) is available.
 
 The official submission for addition to Darwin Core includes the [list of terms](list/) and two guides that explain how the extension must be used ([isLeastSpecificTargetCategoryQuantityInclusive](inclusive/) and [hierarchical events](https://docs.google.com/document/d/1r_XMEgB7p7OI7a5Ouq6G9oa7LmQFPcFhZZCLD9gWOIE/edit?usp=sharing) guidelines). The [Quick reference guide](terms/) and [Usage guide](https://docs.google.com/document/d/1rX4m94rtZDR_8iIe3RvRnNYKDJcmSX3ii4S5hCznEA0/edit?usp=sharing) are not officially part of the addition to Darwin Core, but may provide a less technical point of entry to understanding the extension.


### PR DESCRIPTION
I moved the abstract as a page description and styled the note:

![hc-new](https://github.com/tdwg/hc/assets/600993/b7403cdc-f8e6-42a1-9871-e4947359139c)

For reference, before it looked as follows:

![hc-old](https://github.com/tdwg/hc/assets/600993/1a7b9f4d-c31d-473d-a950-ca6b57ed542e)
